### PR TITLE
Add weather lookup to Nexus assistant

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ speechrecognition
 pyttsx3
 openai
 keyboard
+requests


### PR DESCRIPTION
## Summary
- fetch weather information from OpenWeather and speak the forecast
- detect phrases like "clima en" or "tiempo en" to trigger weather lookup
- add requests dependency

## Testing
- `pip install requests`
- `curl 'https://api.openweathermap.org/data/2.5/weather?q=London&appid=439d4b804bc8187953eb36d2a8c26a02&units=metric&lang=es'` *(failed: CONNECT tunnel failed, response 403)*
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_b_68aecdeea3c0833289ade373cfa5b91d