### PR TITLE
Add basic plugin system

### DIFF
--- a/nexus/__init__.py
+++ b/nexus/__init__.py
@@ -1,0 +1,5 @@
+"""Base package for the Nexus application."""
+
+from .app import main
+
+__all__ = ["main"]

--- a/nexus/app.py
+++ b/nexus/app.py
@@ -1,0 +1,14 @@
+"""Main application logic for the Nexus package."""
+
+from .plugins import load_plugins, iter_plugins
+
+
+def main() -> None:
+    """Entry point for running the Nexus application."""
+    load_plugins()
+    for name, capability in iter_plugins():
+        print(f"Loaded plugin {name}: {capability}")
+
+
+if __name__ == "__main__":
+    main()

--- a/nexus/plugins/__init__.py
+++ b/nexus/plugins/__init__.py
@@ -1,0 +1,40 @@
+"""Plugin system for the Nexus application."""
+
+from importlib import import_module
+import logging
+import pkgutil
+from typing import Any, Dict, Iterable, Tuple
+
+__all__ = [
+    "register_plugin",
+    "load_plugins",
+    "iter_plugins",
+]
+
+_LOGGER = logging.getLogger(__name__)
+_REGISTRY: Dict[str, Any] = {}
+
+
+def register_plugin(name: str, capability: Any) -> None:
+    """Register a plugin capability under the given name."""
+    _REGISTRY[name] = capability
+
+
+def iter_plugins() -> Iterable[Tuple[str, Any]]:
+    """Yield the registered plugin name and capability."""
+    return _REGISTRY.items()
+
+
+def load_plugins() -> None:
+    """Import all plugin modules in this package.
+
+    Any module inside ``nexus.plugins`` is treated as a plugin. Upon import,
+    it is expected to call :func:`register_plugin` to declare its capabilities.
+    Import errors or runtime errors during plugin import are logged but do not
+    stop the application.
+    """
+    for module_info in pkgutil.iter_modules(__path__, prefix=__name__ + "."):
+        try:
+            import_module(module_info.name)
+        except Exception as exc:  # pragma: no cover - defensive
+            _LOGGER.error("Failed to load plugin %s: %s", module_info.name, exc)


### PR DESCRIPTION
## Summary
- add base Nexus package with entry point
- implement dynamic plugin loader and registration API

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_b_68aed8291b3883329c2131d4fc0f4737