### PR TITLE
Add plugin base class and enforce plugin type

### DIFF
--- a/nexus/plugins/__init__.py
+++ b/nexus/plugins/__init__.py
@@ -3,25 +3,34 @@
 from importlib import import_module
 import logging
 import pkgutil
-from typing import Any, Dict, Iterable, Tuple
+from typing import Dict, Iterable, Tuple
+
+from .base import Plugin
 
 __all__ = [
     "register_plugin",
     "load_plugins",
     "iter_plugins",
+    "Plugin",
 ]
 
 _LOGGER = logging.getLogger(__name__)
-_REGISTRY: Dict[str, Any] = {}
+_REGISTRY: Dict[str, Plugin] = {}
 
 
-def register_plugin(name: str, capability: Any) -> None:
-    """Register a plugin capability under the given name."""
+def register_plugin(name: str, capability: Plugin) -> None:
+    """Register a plugin instance under the given name.
+
+    Raises:
+        TypeError: If ``capability`` is not an instance of :class:`Plugin`.
+    """
+    if not isinstance(capability, Plugin):
+        raise TypeError(f"Plugin {name!r} must subclass Plugin")
     _REGISTRY[name] = capability
 
 
-def iter_plugins() -> Iterable[Tuple[str, Any]]:
-    """Yield the registered plugin name and capability."""
+def iter_plugins() -> Iterable[Tuple[str, Plugin]]:
+    """Yield the registered plugin name and instance."""
     return _REGISTRY.items()
 
 
@@ -29,9 +38,9 @@ def load_plugins() -> None:
     """Import all plugin modules in this package.
 
     Any module inside ``nexus.plugins`` is treated as a plugin. Upon import,
-    it is expected to call :func:`register_plugin` to declare its capabilities.
-    Import errors or runtime errors during plugin import are logged but do not
-    stop the application.
+    it is expected to call :func:`register_plugin` with an instance of
+    :class:`Plugin`. Import errors or attempts to register non-conforming
+    objects are logged but do not stop the application.
     """
     for module_info in pkgutil.iter_modules(__path__, prefix=__name__ + "."):
         try:

--- a/nexus/plugins/base.py
+++ b/nexus/plugins/base.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+
+class Plugin(ABC):
+    """Abstract base class for all Nexus plugins.
+
+    Plugins must implement the lifecycle hooks :meth:`load`, :meth:`unload`
+    and :meth:`execute`.
+    """
+
+    @abstractmethod
+    def load(self) -> None:
+        """Perform any setup required before the plugin can be used.
+
+        Returns:
+            None
+
+        Raises:
+            RuntimeError: If the plugin cannot be initialized.
+        """
+
+    @abstractmethod
+    def unload(self) -> None:
+        """Release any resources held by the plugin.
+
+        Returns:
+            None
+
+        Raises:
+            RuntimeError: If cleanup fails.
+        """
+
+    @abstractmethod
+    def execute(self, *args: Any, **kwargs: Any) -> Any:
+        """Run the plugin's main action.
+
+        Args:
+            *args: Positional arguments passed to the plugin.
+            **kwargs: Keyword arguments passed to the plugin.
+
+        Returns:
+            Any: The plugin-specific result of the execution.
+
+        Raises:
+            Exception: Implementations may raise any exception to signal
+                execution failure.
+        """


### PR DESCRIPTION
## Summary
- define `Plugin` abstract class with lifecycle hooks and documentation
- validate registered plugins subclass `Plugin` and expose plugin base
- document loader behavior to ensure plugins register `Plugin` instances

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68aed8e130488332a90d4453416a9c5a