### PR TITLE
feat: add scenarios and external service integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,24 @@ El archivo `config.json` en la raíz del proyecto define los ajustes básicos:
 ```json
 {
   "palabra_clave": "nexus",
-  "hotkey": "ctrl+shift+space"
+  "hotkey": "ctrl+shift+space",
+  "reconocimiento_facial": false,
+  "modo_silencio": false,
+  "escenarios": {
+    "modo de trabajo": [
+      "code",
+      "notepad",
+      "chrome https://www.google.com https://www.notion.so"
+    ]
+  }
 }
 ```
 
 - `palabra_clave`: palabra necesaria para activar el asistente mediante voz.
 - `hotkey`: combinación de teclas para activar el asistente manualmente.
+- `reconocimiento_facial`: si está activo, se pedirá confirmación antes de iniciar.
+- `modo_silencio`: inicia sin salida de voz.
+- `escenarios`: conjuntos de programas que pueden abrirse con el comando "abre <nombre>".
 
 ## Plugins
 
@@ -35,3 +47,12 @@ def register(assistant):
 ```
 
 Los módulos se importan automáticamente al iniciar el programa.
+
+## Integraciones y comandos
+
+- **Escenarios**: define conjuntos de programas en `config.json` y actívalos con `abre <escenario>`.
+- **Hibernación**: di `hiberna` para suspender el equipo.
+- **Modo silencio**: `modo silencio` desactiva la voz y `modo voz` la reactiva.
+- **Notion**: `crea nota <texto>` crea una nota en Notion (requiere `NOTION_TOKEN` y `NOTION_DATABASE_ID`).
+- **Google Calendar**: `reuniones de hoy` muestra los eventos del día (requiere `GOOGLE_CALENDAR_TOKEN`).
+- **Gmail**: `envia correo a <email> <mensaje>` envía un correo mediante Gmail (requiere `GMAIL_USER` y `GMAIL_PASS`).

--- a/config.json
+++ b/config.json
@@ -1,4 +1,13 @@
 {
   "palabra_clave": "nexus",
-  "hotkey": "ctrl+shift+space"
+  "hotkey": "ctrl+shift+space",
+  "reconocimiento_facial": false,
+  "modo_silencio": false,
+  "escenarios": {
+    "modo de trabajo": [
+      "code",
+      "notepad",
+      "chrome https://www.google.com https://www.notion.so"
+    ]
+  }
 }

--- a/plugins/calendar.py
+++ b/plugins/calendar.py
@@ -1,0 +1,46 @@
+"""Consulta básica de eventos en Google Calendar."""
+
+import os
+from datetime import datetime, timedelta, timezone
+import requests
+
+GOOGLE_API = "https://www.googleapis.com/calendar/v3/calendars/{calendar_id}/events"
+
+def register(assistant):
+    def reuniones(text):
+        token = os.getenv("GOOGLE_CALENDAR_TOKEN")
+        calendar_id = os.getenv("GOOGLE_CALENDAR_ID", "primary")
+        if not token:
+            assistant._say("No hay token de Google Calendar.")
+            return
+        now = datetime.now(timezone.utc)
+        start = now.replace(hour=0, minute=0, second=0, microsecond=0)
+        end = start + timedelta(days=1)
+        params = {
+            "timeMin": start.isoformat(),
+            "timeMax": end.isoformat(),
+            "singleEvents": "true",
+            "orderBy": "startTime",
+        }
+        headers = {"Authorization": f"Bearer {token}"}
+        try:
+            resp = requests.get(
+                GOOGLE_API.format(calendar_id=calendar_id),
+                params=params,
+                headers=headers,
+                timeout=10,
+            )
+            if resp.status_code != 200:
+                assistant._say("No se pudo obtener el calendario.")
+                return
+            eventos = resp.json().get("items", [])
+            if not eventos:
+                assistant._say("No hay reuniones hoy.")
+                return
+            for ev in eventos:
+                inicio = ev.get("start", {}).get("dateTime") or ev.get("start", {}).get("date")
+                resumen = ev.get("summary", "Sin título")
+                assistant._say(f"{resumen} a las {inicio}")
+        except Exception:
+            assistant._say("Error al contactar con Google Calendar.")
+    assistant.register_command("reuniones de hoy", reuniones)

--- a/plugins/gmail.py
+++ b/plugins/gmail.py
@@ -1,0 +1,35 @@
+"""Enviar correos mediante Gmail."""
+
+import os
+import smtplib
+from email.mime.text import MIMEText
+
+
+def register(assistant):
+    def enviar(text):
+        resto = text.replace("envia correo a", "", 1).strip()
+        if " " not in resto:
+            assistant._say("Formato: envia correo a correo@dominio.com mensaje")
+            return
+        destino, mensaje = resto.split(" ", 1)
+        user = os.getenv("GMAIL_USER")
+        password = os.getenv("GMAIL_PASS")
+        if not user or not password:
+            assistant._say("Faltan credenciales de Gmail.")
+            return
+        try:
+            msg = MIMEText(mensaje)
+            msg["Subject"] = "Mensaje de Nexus"
+            msg["From"] = user
+            msg["To"] = destino
+            with smtplib.SMTP_SSL("smtp.gmail.com", 465) as server:
+                server.login(user, password)
+                server.send_message(msg)
+            assistant._say("Correo enviado.")
+        except Exception:
+            assistant._say("Error al enviar el correo.")
+    assistant.register_command(
+        "envia correo a",
+        enviar,
+        match_type="startswith",
+    )

--- a/plugins/notion.py
+++ b/plugins/notion.py
@@ -1,0 +1,43 @@
+"""Integración básica con Notion para crear notas."""
+
+import os
+import requests
+
+NOTION_API = "https://api.notion.com/v1/pages"
+NOTION_VERSION = "2022-06-28"
+
+def register(assistant):
+    def crear_nota(text):
+        contenido = text.replace("crea nota", "", 1).strip()
+        token = os.getenv("NOTION_TOKEN")
+        database_id = os.getenv("NOTION_DATABASE_ID")
+        if not contenido:
+            assistant._say("No se proporcionó el contenido de la nota.")
+            return
+        if not token or not database_id:
+            assistant._say("Faltan credenciales de Notion.")
+            return
+        headers = {
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+            "Notion-Version": NOTION_VERSION,
+        }
+        data = {
+            "parent": {"database_id": database_id},
+            "properties": {
+                "title": {"title": [{"text": {"content": contenido}}]}
+            },
+        }
+        try:
+            resp = requests.post(NOTION_API, headers=headers, json=data, timeout=10)
+            if resp.status_code == 200:
+                assistant._say("Nota creada en Notion.")
+            else:
+                assistant._say("Error al crear la nota en Notion.")
+        except Exception:
+            assistant._say("Error al contactar con Notion.")
+    assistant.register_command(
+        "crea nota",
+        crear_nota,
+        match_type="startswith",
+    )

--- a/plugins/scenarios.py
+++ b/plugins/scenarios.py
@@ -1,0 +1,22 @@
+"""Apertura de escenarios configurables."""
+
+import subprocess
+
+
+def register(assistant):
+    escenarios = assistant.config.get("escenarios", {})
+    for nombre, comandos in escenarios.items():
+        def _make_handler(cmds, nombre=nombre):
+            def handler(text):
+                for cmd in cmds:
+                    try:
+                        subprocess.Popen(cmd, shell=True)
+                    except Exception:
+                        pass
+                assistant._say(f"Escenario {nombre} abierto.")
+            return handler
+        assistant.register_command(
+            f"abre {nombre}",
+            _make_handler(comandos),
+            match_type="startswith",
+        )

--- a/plugins/system.py
+++ b/plugins/system.py
@@ -24,6 +24,10 @@ def register(assistant):
         lambda text: (assistant._say("Apagando el ordenador."), assistant._shutdown()),
     )
     assistant.register_command(
+        "hiberna",
+        lambda text: (assistant._say("Hibernando el ordenador."), assistant._hibernate()),
+    )
+    assistant.register_command(
         "salir",
         lambda text: (
             assistant._say("Hasta luego."),
@@ -39,4 +43,12 @@ def register(assistant):
     assistant.register_command(
         "modo encendido",
         lambda text: (setattr(assistant, "active", True), assistant._say("Modo encendido.")),
+    )
+    assistant.register_command(
+        "modo silencio",
+        lambda text: (assistant._say("Modo silencio activado."), setattr(assistant, "silence", True)),
+    )
+    assistant.register_command(
+        "modo voz",
+        lambda text: (setattr(assistant, "silence", False), assistant._say("Modo voz activado.")),
     )


### PR DESCRIPTION
## Summary
- add configurable scenarios to open multiple applications
- include silence mode, hibernate command and optional facial confirmation
- integrate Notion, Google Calendar and Gmail via new plugins

## Testing
- `python -m py_compile main.py plugins/*.py`

------
https://chatgpt.com/codex/tasks/task_b_68aedca9da588332a29ecbfbc2f437ab