### PR TITLE
Add customizable avatars with image upload option

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ El archivo `config.json` en la raíz del proyecto define los ajustes básicos:
   "hotkey": "ctrl+shift+space",
   "reconocimiento_facial": false,
   "modo_silencio": false,
+  "avatar_usuario": "",
+  "avatar_asistente": "",
   "escenarios": {
     "modo de trabajo": [
       "code",
@@ -26,6 +28,8 @@ El archivo `config.json` en la raíz del proyecto define los ajustes básicos:
 - `hotkey`: combinación de teclas para activar el asistente manualmente.
 - `reconocimiento_facial`: si está activo, se pedirá confirmación antes de iniciar.
 - `modo_silencio`: inicia sin salida de voz.
+- `avatar_usuario`: imagen utilizada para los mensajes del usuario.
+- `avatar_asistente`: imagen mostrada en las respuestas del asistente.
 - `escenarios`: conjuntos de programas que pueden abrirse con el comando "abre <nombre>".
 
 ## Plugins

--- a/config.json
+++ b/config.json
@@ -3,6 +3,8 @@
   "hotkey": "ctrl+shift+space",
   "reconocimiento_facial": false,
   "modo_silencio": false,
+  "avatar_usuario": "",
+  "avatar_asistente": "",
   "escenarios": {
     "modo de trabajo": [
       "code",


### PR DESCRIPTION
## Summary
- Allow ChatBubble to display custom avatar images.
- Add avatar settings menu so users can pick built-in styles or upload images.
- Persist selected avatars via new `avatar_usuario` and `avatar_asistente` config entries.

## Testing
- `python -m py_compile gui/app.py main.py`


------
https://chatgpt.com/codex/tasks/task_b_68af2b865114833290ecb02f4bae9e1c