### PR TITLE
feat: load API keys from config

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,15 @@ El archivo `config.json` en la raíz del proyecto define los ajustes básicos:
       "notepad",
       "chrome https://www.google.com https://www.notion.so"
     ]
-  }
+  },
+  "openai_api_key": "",
+  "openweather_api_key": "",
+  "notion_token": "",
+  "notion_database_id": "",
+  "google_calendar_token": "",
+  "google_calendar_id": "",
+  "gmail_user": "",
+  "gmail_pass": ""
 }
 ```
 
@@ -33,6 +41,11 @@ El archivo `config.json` en la raíz del proyecto define los ajustes básicos:
 - `avatar_usuario`: imagen utilizada para los mensajes del usuario.
 - `avatar_asistente`: imagen mostrada en las respuestas del asistente.
 - `escenarios`: conjuntos de programas que pueden abrirse con el comando "abre <nombre>".
+- `openai_api_key`: clave para usar la API de OpenAI.
+- `openweather_api_key`: clave para consultar el clima.
+- `notion_token` y `notion_database_id`: credenciales para Notion.
+- `google_calendar_token` y `google_calendar_id`: credenciales para Google Calendar.
+- `gmail_user` y `gmail_pass`: credenciales de Gmail.
 
 ## Plugins
 
@@ -59,9 +72,9 @@ Los módulos se importan automáticamente al iniciar el programa.
 - **Escenarios**: define conjuntos de programas en `config.json` y actívalos con `abre <escenario>`.
 - **Hibernación**: di `hiberna` para suspender el equipo.
 - **Modo silencio**: `modo silencio` desactiva la voz y `modo voz` la reactiva.
-- **Notion**: `crea nota <texto>` crea una nota en Notion (requiere `NOTION_TOKEN` y `NOTION_DATABASE_ID`).
-- **Google Calendar**: `reuniones de hoy` muestra los eventos del día (requiere `GOOGLE_CALENDAR_TOKEN`).
-- **Gmail**: `envia correo a <email> <mensaje>` envía un correo mediante Gmail (requiere `GMAIL_USER` y `GMAIL_PASS`).
+- **Notion**: `crea nota <texto>` crea una nota en Notion (requiere `notion_token` y `notion_database_id` en `config.json`).
+- **Google Calendar**: `reuniones de hoy` muestra los eventos del día (requiere `google_calendar_token` y opcional `google_calendar_id` en `config.json`).
+- **Gmail**: `envia correo a <email> <mensaje>` envía un correo mediante Gmail (requiere `gmail_user` y `gmail_pass` en `config.json`).
 
 ## Distribución en Windows
 

--- a/config.json
+++ b/config.json
@@ -12,5 +12,13 @@
       "notepad",
       "chrome https://www.google.com https://www.notion.so"
     ]
-  }
+  },
+  "openai_api_key": "",
+  "openweather_api_key": "",
+  "notion_token": "",
+  "notion_database_id": "",
+  "google_calendar_token": "",
+  "google_calendar_id": "",
+  "gmail_user": "",
+  "gmail_pass": ""
 }

--- a/main.py
+++ b/main.py
@@ -85,7 +85,7 @@ class NexusAssistant:
 
     # Acciones -------------------------------------------------------------------
     def _chatgpt(self, text: str) -> None:
-        api_key = os.getenv("OPENAI_API_KEY")
+        api_key = self.config.get("openai_api_key") or os.getenv("OPENAI_API_KEY")
         if not api_key:
             self.speak("No hay clave de API configurada.")
             return
@@ -166,7 +166,7 @@ class NexusAssistant:
             self.speak("Número de nota inválido.")
 
     def _get_weather(self, ciudad: str) -> None:
-        api_key = os.getenv("OPENWEATHER_API_KEY")
+        api_key = self.config.get("openweather_api_key") or os.getenv("OPENWEATHER_API_KEY")
         if not api_key:
             self.speak("No hay clave de API de OpenWeather configurada.")
             return

--- a/plugins/calendar.py
+++ b/plugins/calendar.py
@@ -8,8 +8,12 @@ GOOGLE_API = "https://www.googleapis.com/calendar/v3/calendars/{calendar_id}/eve
 
 def register(assistant):
     def reuniones(text):
-        token = os.getenv("GOOGLE_CALENDAR_TOKEN")
-        calendar_id = os.getenv("GOOGLE_CALENDAR_ID", "primary")
+        token = assistant.config.get("google_calendar_token") or os.getenv("GOOGLE_CALENDAR_TOKEN")
+        calendar_id = (
+            assistant.config.get("google_calendar_id")
+            or os.getenv("GOOGLE_CALENDAR_ID")
+            or "primary"
+        )
         if not token:
             assistant.speak("No hay token de Google Calendar.")
             return

--- a/plugins/gmail.py
+++ b/plugins/gmail.py
@@ -12,8 +12,8 @@ def register(assistant):
             assistant.speak("Formato: envia correo a correo@dominio.com mensaje")
             return
         destino, mensaje = resto.split(" ", 1)
-        user = os.getenv("GMAIL_USER")
-        password = os.getenv("GMAIL_PASS")
+        user = assistant.config.get("gmail_user") or os.getenv("GMAIL_USER")
+        password = assistant.config.get("gmail_pass") or os.getenv("GMAIL_PASS")
         if not user or not password:
             assistant.speak("Faltan credenciales de Gmail.")
             return

--- a/plugins/notion.py
+++ b/plugins/notion.py
@@ -9,8 +9,8 @@ NOTION_VERSION = "2022-06-28"
 def register(assistant):
     def crear_nota(text):
         contenido = text.replace("crea nota", "", 1).strip()
-        token = os.getenv("NOTION_TOKEN")
-        database_id = os.getenv("NOTION_DATABASE_ID")
+        token = assistant.config.get("notion_token") or os.getenv("NOTION_TOKEN")
+        database_id = assistant.config.get("notion_database_id") or os.getenv("NOTION_DATABASE_ID")
         if not contenido:
             assistant.speak("No se proporcionó el contenido de la nota.")
             return


### PR DESCRIPTION
## Summary
- allow Nexus to pull OpenAI and OpenWeather tokens from `config.json`
- read Notion, Google Calendar, and Gmail credentials from `config.json`
- document new API key fields in config and README

## Testing
- `pytest`
- `python -m py_compile main.py plugins/*.py`


------
https://chatgpt.com/codex/tasks/task_b_68af337e1ab08332beb8f1d85aedee47