### PR TITLE
Prompt for city before weather lookup

### DIFF
--- a/gui/app.py
+++ b/gui/app.py
@@ -21,6 +21,7 @@ from PySide6.QtWidgets import (
     QHBoxLayout,
     QLabel,
     QLineEdit,
+    QInputDialog,
     QMainWindow,
     QMenu,
     QScrollArea,
@@ -506,6 +507,18 @@ class ChatWindow(QMainWindow):
         self.add_message(text, is_user=False)
 
     def _use_suggestion(self, text: str) -> None:
+        if text == "¿Qué clima hay?":
+            ciudad, ok = QInputDialog.getText(self, "Clima", "¿En qué ciudad?")
+            if ok and ciudad.strip():
+                bubble = self.add_message(f"Clima en {ciudad}", True)
+                QTimer.singleShot(200, bubble.show_status_sent)
+                self._show_typing()
+                threading.Thread(
+                    target=self._process_text,
+                    args=(f"clima en {ciudad}",),
+                    daemon=True,
+                ).start()
+            return
         self.input.setText(text)
         self.send_message()
 


### PR DESCRIPTION
## Summary
- Ask for city when the quick weather suggestion is used
- Fetch weather via existing command instead of sending text to ChatGPT

## Testing
- `python -m py_compile gui/app.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68af40e7145883328b84f25a574b4fa2